### PR TITLE
Add detekt 1.12

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,6 +29,10 @@ jobs:
         key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
         restore-keys: ${{ runner.os }}-gradle
     - name: Build with Gradle
-      run: ./gradlew build --info
+      run: ./gradlew build -x check --info
+    - name: Run tests with Gradle
+      run: ./gradlew test --info
       env:
         MYSQL_PORT: ${{ job.services.mysql.ports[3306] }}
+    - name: Run detekt with Gradle
+      run: ./gradlew detekt --info

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,11 +1,18 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
+buildscript {
+    repositories {
+        jcenter()
+    }
+}
+
 plugins {
     id("org.springframework.boot") version "2.3.4.RELEASE"
     id("io.spring.dependency-management") version "1.0.10.RELEASE"
     kotlin("jvm") version "1.3.72"
     kotlin("plugin.spring") version "1.3.72"
     kotlin("plugin.jpa") version "1.3.72"
+    id("io.gitlab.arturbosch.detekt") version "1.14.1"
 }
 
 group = "io.testaxis"
@@ -14,6 +21,7 @@ java.sourceCompatibility = JavaVersion.VERSION_11
 
 repositories {
     mavenCentral()
+    jcenter()
 }
 
 dependencies {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,7 +12,7 @@ plugins {
     kotlin("jvm") version "1.3.72"
     kotlin("plugin.spring") version "1.3.72"
     kotlin("plugin.jpa") version "1.3.72"
-    id("io.gitlab.arturbosch.detekt") version "1.14.1"
+    id("io.gitlab.arturbosch.detekt") version "1.11.0"
 }
 
 group = "io.testaxis"

--- a/src/main/kotlin/io/testaxis/backend/TestAxisBackendApplication.kt
+++ b/src/main/kotlin/io/testaxis/backend/TestAxisBackendApplication.kt
@@ -7,5 +7,6 @@ import org.springframework.boot.runApplication
 class TestAxisBackendApplication
 
 fun main(args: Array<String>) {
+    @Suppress("SpreadOperator")
     runApplication<TestAxisBackendApplication>(*args)
 }


### PR DESCRIPTION
Since the newest version of detekt is not working correctly (see #11), this PR adds version 1.12 for now. It also includes detekt in the GitHub actions, and it fixes a small issue ~detekted~ detected by detekt.