### PR TITLE
Add continuous deployment to Heroku and switch to Postgres

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,17 @@
+name: Deploy
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: akhileshns/heroku-deploy@v3.5.7
+        with:
+          heroku_api_key: ${{secrets.HEROKU_API_KEY}}
+          heroku_app_name: "testaxis-io"
+          heroku_email: "heroku@casperboone.nl"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,9 +9,11 @@ buildscript {
 plugins {
     id("org.springframework.boot") version "2.3.4.RELEASE"
     id("io.spring.dependency-management") version "1.0.10.RELEASE"
+
     kotlin("jvm") version "1.4.10"
     kotlin("plugin.spring") version "1.4.10"
     kotlin("plugin.jpa") version "1.4.10"
+
     id("io.gitlab.arturbosch.detekt") version "1.14.1"
     id("org.jlleitschuh.gradle.ktlint") version "9.4.1"
 }
@@ -35,6 +37,7 @@ dependencies {
     developmentOnly("org.springframework.boot:spring-boot-devtools")
     runtimeOnly("com.h2database:h2")
     runtimeOnly("mysql:mysql-connector-java")
+    runtimeOnly("org.postgresql:postgresql")
     testImplementation("org.springframework.boot:spring-boot-starter-test") {
         exclude(group = "org.junit.vintage", module = "junit-vintage-engine")
     }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,4 +1,4 @@
-spring.jpa.database-platform  = org.hibernate.dialect.MySQL8Dialect
+spring.jpa.database-platform  = org.hibernate.dialect.PostgreSQLDialect
 spring.jpa.show-sql           = true
 spring.jpa.hibernate.ddl-auto = update
 spring.datasource.url         = jdbc:mysql://${MYSQL_HOST:localhost}:3306/testaxis?serverTimezone=Europe/Amsterdam

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,6 +1,4 @@
 spring.jpa.database-platform  = org.hibernate.dialect.PostgreSQLDialect
 spring.jpa.show-sql           = true
 spring.jpa.hibernate.ddl-auto = update
-spring.datasource.url         = jdbc:mysql://${MYSQL_HOST:localhost}:3306/testaxis?serverTimezone=Europe/Amsterdam
-spring.datasource.username    = root
-spring.datasource.password    =
+spring.datasource.url         = jdbc:postgresql:testaxis

--- a/system.properties
+++ b/system.properties
@@ -1,0 +1,1 @@
+java.runtime.version=11


### PR DESCRIPTION
This PR adds a workflow to deploy to Heroku.

Since it is easier to use Postgres on Heroku, and because it does not really matter for our application, MySQL is switched to Postgres.