### PR TITLE
Add endpoint for uploading XML test reports

### DIFF
--- a/src/main/kotlin/io/testaxis/backend/actions/ParseJUnitXML.kt
+++ b/src/main/kotlin/io/testaxis/backend/actions/ParseJUnitXML.kt
@@ -2,7 +2,9 @@ package io.testaxis.backend.actions
 
 import io.testaxis.backend.models.TestCase
 import io.testaxis.backend.models.TestSuite
+import org.springframework.stereotype.Component
 import org.w3c.dom.Element
+import java.io.InputStream
 import javax.xml.parsers.DocumentBuilderFactory
 
 /**
@@ -17,6 +19,7 @@ fun Element.getChildElementsByTagName(tagName: String) = getElementsByTagName(ta
  */
 fun Element.getChildElementByTagName(tagName: String) = getChildElementsByTagName(tagName).firstOrNull()
 
+@Component
 class ParseJUnitXML {
     /**
      * Parses one or more XML documents to a collection of [TestSuite]s.
@@ -24,8 +27,7 @@ class ParseJUnitXML {
      * In case multiple documents are provided, a flattened collection will be returned where all the testsuites of all
      * the documents are at the same level.
      */
-    operator fun invoke(vararg documents: String) = documents
-        .map { it.byteInputStream() }
+    operator fun invoke(documents: List<InputStream>): List<TestSuite> = documents
         .map { DocumentBuilderFactory.newInstance().newDocumentBuilder().parse(it) }
         .map {
             it.documentElement.normalize()
@@ -56,6 +58,7 @@ class ParseJUnitXML {
     /**
      * Parses a list of <testcase> nodes into a list of [TestCase] objects.
      */
+    @Suppress("ForbiddenComment") // TODO: parse <skipped /> and maybe <error ..> ?
     private fun parseTestCases(elements: List<Element>) = elements.map {
         TestCase(
             name = it.getAttribute("name"),

--- a/src/main/kotlin/io/testaxis/backend/http/controllers/ReportsController.kt
+++ b/src/main/kotlin/io/testaxis/backend/http/controllers/ReportsController.kt
@@ -1,0 +1,23 @@
+package io.testaxis.backend.http.controllers
+
+import io.testaxis.backend.actions.ParseJUnitXML
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.multipart.MultipartFile
+
+@RestController
+class ReportsController(val parser: ParseJUnitXML) {
+    @PostMapping("reports")
+    fun store(@RequestParam("files") files: Array<MultipartFile>): String {
+        val testSuites = parser(files.map { it.inputStream })
+
+        return """
+            -------------------------------------------
+            TestAxis -- Upload Successful
+            -------------------------------------------
+            Found the reported executions of ${testSuites.sumOf { it.testCases.count() }} tests.
+            -------------------------------------------
+        """.trimIndent()
+    }
+}

--- a/src/test/kotlin/io/testaxis/backend/actions/ParseJUnitXMLTest.kt
+++ b/src/test/kotlin/io/testaxis/backend/actions/ParseJUnitXMLTest.kt
@@ -30,7 +30,7 @@ class ParseJUnitXMLTest {
 
     @Test
     fun `It parses a single XML test report with a _testsuite_ root element`() {
-        val testSuites = ParseJUnitXML()(testReport)
+        val testSuites = ParseJUnitXML()(listOf(testReport.byteInputStream()))
 
         expectThat(testSuites) hasSize 1
         expectThat(testSuites[0].name) isEqualTo "io.testaxis.backend.http.controllers.ProjectControllerTest"
@@ -38,7 +38,7 @@ class ParseJUnitXMLTest {
 
     @Test
     fun `It parses multiple XML test report with a _testsuite_ root element`() {
-        val testSuites = ParseJUnitXML()(testReport, testReport)
+        val testSuites = ParseJUnitXML()(listOf(testReport.byteInputStream(), testReport.byteInputStream()))
 
         expectThat(testSuites) hasSize 2
         expectThat(testSuites[0].name) isEqualTo "io.testaxis.backend.http.controllers.ProjectControllerTest"
@@ -57,7 +57,7 @@ class ParseJUnitXMLTest {
 
     @Test
     fun `It parses a _testsuite_ element`() {
-        val testSuites = ParseJUnitXML()(testReport)
+        val testSuites = ParseJUnitXML()(listOf(testReport.byteInputStream()))
 
         with(testSuites[0]) {
             expectThat(name) isEqualTo "io.testaxis.backend.http.controllers.ProjectControllerTest"
@@ -71,14 +71,14 @@ class ParseJUnitXMLTest {
 
     @Test
     fun `It finds and parses the _testcase_ elements`() {
-        val testSuites = ParseJUnitXML()(testReport)
+        val testSuites = ParseJUnitXML()(listOf(testReport.byteInputStream()))
 
         expectThat(testSuites[0].testCases) hasSize 2
     }
 
     @Test
     fun `It parses failing _testcase_ elements`() {
-        val testSuites = ParseJUnitXML()(testReport)
+        val testSuites = ParseJUnitXML()(listOf(testReport.byteInputStream()))
 
         with(testSuites[0].testCases[0]) {
             expectThat(name) isEqualTo "A user can retrieve no projects at all()"
@@ -96,7 +96,7 @@ class ParseJUnitXMLTest {
 
     @Test
     fun `It parses passing _testcase_ elements`() {
-        val testSuites = ParseJUnitXML()(testReport)
+        val testSuites = ParseJUnitXML()(listOf(testReport.byteInputStream()))
 
         with(testSuites[0].testCases[1]) {
             expectThat(name) isEqualTo "A user can retrieve all projects()"

--- a/src/test/kotlin/io/testaxis/backend/http/controllers/ReportsControllerTest.kt
+++ b/src/test/kotlin/io/testaxis/backend/http/controllers/ReportsControllerTest.kt
@@ -1,0 +1,57 @@
+package io.testaxis.backend.http.controllers
+
+import org.hamcrest.Matchers.containsString
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.http.MediaType
+import org.springframework.mock.web.MockMultipartFile
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.multipart
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class ReportsControllerTest(@Autowired val mockMvc: MockMvc) {
+    private val testReport =
+        """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <testsuite name="io.testaxis.backend.http.controllers.ProjectControllerTest" tests="2" skipped="0" failures="2" errors="0" timestamp="2020-10-14T13:22:46" time="0.081">
+                <properties/>
+                <testcase name="A user can retrieve no projects at all()" classname="io.testaxis.backend.http.controllers.ProjectControllerTest" time="0.038">
+                    <failure message="java.lang.AssertionError: []: Expected 0 values but got 4" type="java.lang.AssertionError">java.lang.AssertionError: []: Expected 0 values but got 4
+                        at org.skyscreamer.jsonassert.JSONAssert.assertEquals(JSONAssert.java:417)
+                        (...)
+                        at java.base/java.lang.Thread.run(Thread.java:834)
+                    </failure>
+                </testcase>
+                <testcase name="A user can retrieve all projects()" classname="io.testaxis.backend.http.controllers.ProjectControllerTest" time="0.042" />
+            </testsuite>
+        """.trimIndent()
+
+    @Test
+    fun `A user can upload a single XML test report`() {
+        mockMvc.multipart("/reports") {
+            file(fakeTestReport())
+        }.andExpect {
+            content { string(containsString("2 tests")) }
+        }
+    }
+
+    @Test
+    fun `A user can upload multiple XML test reports`() {
+        mockMvc.multipart("/reports") {
+            file(fakeTestReport())
+            file(fakeTestReport())
+        }.andExpect {
+            content { string(containsString("4 tests")) }
+        }
+    }
+
+    private fun fakeTestReport() = MockMultipartFile(
+        "files",
+        "test_report.xml",
+        MediaType.TEXT_XML_VALUE,
+        testReport.byteInputStream()
+    )
+}


### PR DESCRIPTION
The endpoint can be used as follows:
```
curl -X POST \
  http://localhost:8080/reports \
  -H 'content-type: multipart/form-data' \
  -F files=@fileA.xml \
  -F files=@fileB.xml
```

The results are not yet persisted.

Closes #6,