### PR TITLE
Add endpoint for test case executions

### DIFF
--- a/src/main/kotlin/io/testaxis/backend/exceptions/ExceptionHandlers.kt
+++ b/src/main/kotlin/io/testaxis/backend/exceptions/ExceptionHandlers.kt
@@ -1,4 +1,4 @@
-package io.testaxis.backend.http
+package io.testaxis.backend.exceptions
 
 import org.springframework.http.HttpStatus
 import org.springframework.validation.BindException

--- a/src/main/kotlin/io/testaxis/backend/exceptions/ResourceNotFoundException.kt
+++ b/src/main/kotlin/io/testaxis/backend/exceptions/ResourceNotFoundException.kt
@@ -1,0 +1,8 @@
+package io.testaxis.backend.exceptions
+
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.ResponseStatus
+import java.lang.RuntimeException
+
+@ResponseStatus(HttpStatus.NOT_FOUND)
+class ResourceNotFoundException : RuntimeException()

--- a/src/main/kotlin/io/testaxis/backend/http/Validators.kt
+++ b/src/main/kotlin/io/testaxis/backend/http/Validators.kt
@@ -1,5 +1,6 @@
 package io.testaxis.backend.http
 
+import io.testaxis.backend.exceptions.ResourceNotFoundException
 import org.springframework.web.multipart.MultipartFile
 import javax.validation.Constraint
 import javax.validation.ConstraintValidator
@@ -60,4 +61,24 @@ class FilesHaveMaxSizeValidator : ConstraintValidator<FilesHaveMaxSize, Array<Mu
 
     override fun isValid(files: Array<MultipartFile>, context: ConstraintValidatorContext) =
         files.all { it.size < size }
+}
+
+/**
+ * Validation annotation to validate that a bounded resource from a path variable exists.
+ */
+@Target(AnnotationTarget.VALUE_PARAMETER)
+@MustBeDocumented
+@Constraint(validatedBy = [MustExistValidator::class])
+annotation class MustExist(
+    val message: String = "This resource does not exist.",
+    val groups: Array<KClass<*>> = [],
+    val payload: Array<KClass<out Payload>> = []
+)
+
+/**
+ * Validator implementation for [FilesHaveMaxSize].
+ */
+class MustExistValidator : ConstraintValidator<MustExist, Any?> {
+    override fun isValid(value: Any?, context: ConstraintValidatorContext) =
+        if (value == null) throw ResourceNotFoundException() else true
 }

--- a/src/main/kotlin/io/testaxis/backend/http/controllers/api/BuildsController.kt
+++ b/src/main/kotlin/io/testaxis/backend/http/controllers/api/BuildsController.kt
@@ -1,0 +1,13 @@
+package io.testaxis.backend.http.controllers.api
+
+import io.testaxis.backend.repositories.BuildRepository
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/v1/builds")
+class BuildsController(val buildRepository: BuildRepository) {
+    @GetMapping
+    fun index() = buildRepository.findAll()
+}

--- a/src/main/kotlin/io/testaxis/backend/http/controllers/api/BuildsController.kt
+++ b/src/main/kotlin/io/testaxis/backend/http/controllers/api/BuildsController.kt
@@ -1,13 +1,14 @@
 package io.testaxis.backend.http.controllers.api
 
-import io.testaxis.backend.repositories.BuildRepository
+import io.testaxis.backend.models.Project
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
-@RequestMapping("/api/v1/builds")
-class BuildsController(val buildRepository: BuildRepository) {
+@RequestMapping("/api/v1/projects/{project}/builds")
+class BuildsController {
     @GetMapping
-    fun index() = buildRepository.findAll()
+    fun index(@PathVariable project: Project) = project.builds
 }

--- a/src/main/kotlin/io/testaxis/backend/http/controllers/api/BuildsController.kt
+++ b/src/main/kotlin/io/testaxis/backend/http/controllers/api/BuildsController.kt
@@ -1,6 +1,8 @@
 package io.testaxis.backend.http.controllers.api
 
+import io.testaxis.backend.http.MustExist
 import io.testaxis.backend.models.Project
+import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
@@ -8,7 +10,8 @@ import org.springframework.web.bind.annotation.RestController
 
 @RestController
 @RequestMapping("/api/v1/projects/{project}/builds")
+@Validated
 class BuildsController {
     @GetMapping
-    fun index(@PathVariable project: Project) = project.builds
+    fun index(@PathVariable @MustExist project: Project) = project.builds
 }

--- a/src/main/kotlin/io/testaxis/backend/http/controllers/api/ProjectsController.kt
+++ b/src/main/kotlin/io/testaxis/backend/http/controllers/api/ProjectsController.kt
@@ -1,11 +1,13 @@
-package io.testaxis.backend.http.controllers
+package io.testaxis.backend.http.controllers.api
 
 import io.testaxis.backend.repositories.ProjectRepository
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
+@RequestMapping("/api/v1/projects")
 class ProjectsController(val projectsRepository: ProjectRepository) {
-    @GetMapping("/projects")
+    @GetMapping
     fun index() = projectsRepository.findAll()
 }

--- a/src/main/kotlin/io/testaxis/backend/http/controllers/api/TestCaseExecutionsController.kt
+++ b/src/main/kotlin/io/testaxis/backend/http/controllers/api/TestCaseExecutionsController.kt
@@ -1,0 +1,29 @@
+package io.testaxis.backend.http.controllers.api
+
+import io.testaxis.backend.http.MustExist
+import io.testaxis.backend.http.transformers.TestCaseExecutionTransformer
+import io.testaxis.backend.models.Build
+import io.testaxis.backend.models.TestCaseExecution
+import org.springframework.validation.annotation.Validated
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import javax.transaction.Transactional
+
+@RestController
+@Transactional
+@RequestMapping("/api/v1/projects/{project}/builds/{build}/testcaseexecutions")
+@Validated
+class TestCaseExecutionsController(val transformer: TestCaseExecutionTransformer) {
+    @Suppress("ForbiddenComment")
+    // TODO: scope build by project
+    @GetMapping
+    fun index(@PathVariable @MustExist build: Build) =
+        transformer.transform(build.testCaseExecutions!!, transformer::summary)
+
+    @Suppress("ForbiddenComment")
+    // TODO: scope execution by build and project
+    @GetMapping("/{testCaseExecution}")
+    fun show(@PathVariable @MustExist testCaseExecution: TestCaseExecution) = transformer.details(testCaseExecution)
+}

--- a/src/main/kotlin/io/testaxis/backend/http/transformers/TestCaseExecutionTransformer.kt
+++ b/src/main/kotlin/io/testaxis/backend/http/transformers/TestCaseExecutionTransformer.kt
@@ -1,0 +1,25 @@
+package io.testaxis.backend.http.transformers
+
+import io.testaxis.backend.http.transformers.dsl.Transformer
+import io.testaxis.backend.models.TestCaseExecution
+import org.springframework.stereotype.Component
+
+@Component
+class TestCaseExecutionTransformer : Transformer() {
+    fun summary(testCaseExecution: TestCaseExecution) = transform(testCaseExecution) {
+        "id" - id
+        "build_id" - build.id
+        "test_suite_name" - testSuiteName
+        "name" - name
+        "class_name" - className
+        "time" - time
+        "passed" - passed
+        "created_at" - createdAt
+    }
+
+    fun details(testCaseExecution: TestCaseExecution) = transform(testCaseExecution, ::summary) {
+        "failure_message" - failureMessage
+        "failure_type" - failureType
+        "failure_content" - failureContent
+    }
+}

--- a/src/main/kotlin/io/testaxis/backend/http/transformers/dsl/TransformerDsl.kt
+++ b/src/main/kotlin/io/testaxis/backend/http/transformers/dsl/TransformerDsl.kt
@@ -1,0 +1,30 @@
+package io.testaxis.backend.http.transformers.dsl
+
+typealias KeyValueData = Map<String, Any?>
+typealias converter<T> = (T) -> KeyValueData
+
+abstract class Transformer {
+    private var data = mutableMapOf<String, Any?>()
+
+    protected infix operator fun <T> String.minus(value: T) {
+        data[this] = value
+    }
+
+    protected fun <T> transform(
+        entity: T,
+        vararg extendConverters: converter<T>,
+        convertData: T.() -> Unit
+    ): KeyValueData {
+        val extendedConvertersData = extendConverters.fold(mapOf<String, Any?>()) { data, convert ->
+            data + convert(entity)
+        }
+
+        data = mutableMapOf()
+        entity.convertData()
+
+        return extendedConvertersData + data
+    }
+
+    fun <T> transform(entities: List<T>, converter: converter<T>) = entities.map(converter)
+}
+

--- a/src/main/kotlin/io/testaxis/backend/http/transformers/dsl/TransformerDsl.kt
+++ b/src/main/kotlin/io/testaxis/backend/http/transformers/dsl/TransformerDsl.kt
@@ -3,6 +3,7 @@ package io.testaxis.backend.http.transformers.dsl
 typealias KeyValueData = Map<String, Any?>
 typealias converter<T> = (T) -> KeyValueData
 
+@Suppress("UnnecessaryAbstractClass")
 abstract class Transformer {
     private var data = mutableMapOf<String, Any?>()
 
@@ -27,4 +28,3 @@ abstract class Transformer {
 
     fun <T> transform(entities: List<T>, converter: converter<T>) = entities.map(converter)
 }
-

--- a/src/main/kotlin/io/testaxis/backend/models/Build.kt
+++ b/src/main/kotlin/io/testaxis/backend/models/Build.kt
@@ -10,11 +10,13 @@ import javax.persistence.GeneratedValue
 import javax.persistence.GenerationType
 import javax.persistence.Id
 import javax.persistence.JoinColumn
+import javax.persistence.ManyToOne
 import javax.persistence.OneToMany
 
 @Entity
 data class Build(
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY) val id: Long? = null,
+    @ManyToOne @JoinColumn(name = "project_id") val project: Project,
     val branch: String,
     val commit: String,
     val slug: String,
@@ -25,7 +27,7 @@ data class Build(
     val serviceBuildUrl: String? = null,
     val serviceJob: String? = null,
     @JsonIgnore @OneToMany(fetch = FetchType.LAZY) @JoinColumn(name = "build_id")
-    val testCaseExecutions: List<TestCaseExecution> = emptyList(),
+    val testCaseExecutions: List<TestCaseExecution>? = null,
     @CreatedDate val createdAt: Date = Date(),
     @Suppress("ForbiddenComment") // TODO: Fix @CreatedDate and @LastModifiedDate annotations
     @LastModifiedDate val updatedAt: Date = Date(),

--- a/src/main/kotlin/io/testaxis/backend/models/Build.kt
+++ b/src/main/kotlin/io/testaxis/backend/models/Build.kt
@@ -1,6 +1,6 @@
 package io.testaxis.backend.models
 
-import com.fasterxml.jackson.annotation.JsonFormat
+import com.fasterxml.jackson.annotation.JsonIgnore
 import org.springframework.data.annotation.CreatedDate
 import org.springframework.data.annotation.LastModifiedDate
 import java.util.Date
@@ -24,7 +24,7 @@ data class Build(
     val serviceBuild: String? = null,
     val serviceBuildUrl: String? = null,
     val serviceJob: String? = null,
-    @OneToMany(fetch = FetchType.EAGER) @JoinColumn(name = "build_id")
+    @JsonIgnore @OneToMany(fetch = FetchType.LAZY) @JoinColumn(name = "build_id")
     val testCaseExecutions: List<TestCaseExecution> = emptyList(),
     @CreatedDate val createdAt: Date = Date(),
     @Suppress("ForbiddenComment") // TODO: Fix @CreatedDate and @LastModifiedDate annotations

--- a/src/main/kotlin/io/testaxis/backend/models/Build.kt
+++ b/src/main/kotlin/io/testaxis/backend/models/Build.kt
@@ -1,5 +1,6 @@
 package io.testaxis.backend.models
 
+import com.fasterxml.jackson.annotation.JsonFormat
 import org.springframework.data.annotation.CreatedDate
 import org.springframework.data.annotation.LastModifiedDate
 import java.util.Date
@@ -14,9 +15,9 @@ import javax.persistence.OneToMany
 @Entity
 data class Build(
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY) val id: Long? = null,
-    val branch: String = "",
-    val commit: String = "",
-    val slug: String = "",
+    val branch: String,
+    val commit: String,
+    val slug: String,
     val tag: String? = null,
     val pr: String? = null,
     val service: String? = null,

--- a/src/main/kotlin/io/testaxis/backend/models/Project.kt
+++ b/src/main/kotlin/io/testaxis/backend/models/Project.kt
@@ -1,12 +1,23 @@
 package io.testaxis.backend.models
 
+import com.fasterxml.jackson.annotation.JsonIgnore
 import javax.persistence.Entity
+import javax.persistence.FetchType
 import javax.persistence.GeneratedValue
 import javax.persistence.GenerationType
 import javax.persistence.Id
+import javax.persistence.JoinColumn
+import javax.persistence.OneToMany
 
 @Entity
 data class Project(
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY) val id: Long? = null,
-    val name: String
-)
+    val slug: String,
+    val name: String,
+    @JsonIgnore @OneToMany(fetch = FetchType.LAZY) @JoinColumn(name = "project_id")
+    val builds: List<Build>? = null,
+) {
+    companion object {
+        fun splitNameFromSlug(slug: String) = slug.split('/')[0]
+    }
+}

--- a/src/main/kotlin/io/testaxis/backend/repositories/ProjectRepository.kt
+++ b/src/main/kotlin/io/testaxis/backend/repositories/ProjectRepository.kt
@@ -5,4 +5,15 @@ import org.springframework.data.repository.CrudRepository
 import org.springframework.stereotype.Repository
 
 @Repository
-interface ProjectRepository : CrudRepository<Project, Long>
+interface ProjectRepository : CrudRepository<Project, Long>, CustomProjectRepository {
+    fun findBySlug(slug: String): Project?
+}
+
+interface CustomProjectRepository {
+    fun findBySlugOrCreate(slug: String): Project
+}
+
+class CustomProjectRepositoryImpl(val repository: ProjectRepository) : CustomProjectRepository {
+    override fun findBySlugOrCreate(slug: String): Project =
+        repository.findBySlug(slug) ?: repository.save(Project(name = Project.splitNameFromSlug(slug), slug = slug))
+}

--- a/src/main/kotlin/io/testaxis/backend/repositories/TestCaseExecutionRepository.kt
+++ b/src/main/kotlin/io/testaxis/backend/repositories/TestCaseExecutionRepository.kt
@@ -1,8 +1,13 @@
 package io.testaxis.backend.repositories
 
+import io.testaxis.backend.models.Build
 import io.testaxis.backend.models.TestCaseExecution
 import org.springframework.data.repository.CrudRepository
 import org.springframework.stereotype.Repository
+import javax.transaction.Transactional
 
 @Repository
-interface TestCaseExecutionRepository : CrudRepository<TestCaseExecution, Long>
+@Transactional
+interface TestCaseExecutionRepository : CrudRepository<TestCaseExecution, Long> {
+    fun findByBuild(build: Build): List<TestCaseExecution>
+}

--- a/src/main/kotlin/io/testaxis/backend/services/ReportService.kt
+++ b/src/main/kotlin/io/testaxis/backend/services/ReportService.kt
@@ -4,12 +4,14 @@ import io.testaxis.backend.actions.ParseJUnitXML
 import io.testaxis.backend.models.Build
 import io.testaxis.backend.models.TestCaseExecution
 import io.testaxis.backend.repositories.BuildRepository
+import io.testaxis.backend.repositories.ProjectRepository
 import io.testaxis.backend.repositories.TestCaseExecutionRepository
 import org.springframework.stereotype.Service
 import java.io.InputStream
 
 @Service
 class ReportService(
+    val projectRepository: ProjectRepository,
     val buildRepository: BuildRepository,
     val testCaseExecutionRepository: TestCaseExecutionRepository,
     val parser: ParseJUnitXML

--- a/src/test/kotlin/io/testaxis/backend/TestHelpers.kt
+++ b/src/test/kotlin/io/testaxis/backend/TestHelpers.kt
@@ -9,7 +9,9 @@ import strikt.api.expectThat
 import strikt.assertions.containsKey
 import java.nio.charset.StandardCharsets
 
-fun ContentResultMatchers.jsonContent(value: Any) = json(ObjectMapper().writeValueAsString(value))
+const val API_ROUTE_PREFIX = "/api/v1"
+
+fun ContentResultMatchers.jsonContent(value: Any) = json(ObjectMapper().writer().withDefaultPrettyPrinter().writeValueAsString(value))
 
 fun ContentResultMatchers.jsonContent(vararg values: Any) = jsonContent(values)
 
@@ -20,3 +22,5 @@ fun ContentResultMatchers.hasValidationError(key: String) = ResultMatcher { resu
 
     expectThat(parsedJson).containsKey(key)
 }
+
+fun apiRoute(url: String) = API_ROUTE_PREFIX + url

--- a/src/test/kotlin/io/testaxis/backend/http/controllers/api/BuildsControllerTest.kt
+++ b/src/test/kotlin/io/testaxis/backend/http/controllers/api/BuildsControllerTest.kt
@@ -2,7 +2,9 @@ package io.testaxis.backend.http.controllers.api
 
 import io.testaxis.backend.apiRoute
 import io.testaxis.backend.models.Build
+import io.testaxis.backend.models.Project
 import io.testaxis.backend.repositories.BuildRepository
+import io.testaxis.backend.repositories.ProjectRepository
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
@@ -10,16 +12,23 @@ import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.http.MediaType
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.get
+import javax.transaction.Transactional
 
 @SpringBootTest
+@Transactional
 @AutoConfigureMockMvc
-class BuildsControllerTest(@Autowired val mockMvc: MockMvc, @Autowired val buildRepository: BuildRepository) {
+class BuildsControllerTest(
+    @Autowired val mockMvc: MockMvc,
+    @Autowired val buildRepository: BuildRepository,
+    @Autowired val projectRepository: ProjectRepository
+) {
     @Test
     fun `A user can retrieve all builds for a given project`() {
+        val project = projectRepository.save(Project(name = "project", slug = "org/project"))
         val builds = buildRepository.saveAll(
             listOf(
-                Build(branch = "new-feature", commit = "a212a3", slug = "org/project"),
-                Build(branch = "fix-bug", commit = "b72a73", slug = "org/other-project"),
+                Build(project = project, branch = "new-feature", commit = "a212a3", slug = "org/project"),
+                Build(project = project, branch = "fix-bug", commit = "b72a73", slug = "org/other-project"),
             )
         ).toList()
 

--- a/src/test/kotlin/io/testaxis/backend/http/controllers/api/BuildsControllerTest.kt
+++ b/src/test/kotlin/io/testaxis/backend/http/controllers/api/BuildsControllerTest.kt
@@ -1,0 +1,42 @@
+package io.testaxis.backend.http.controllers.api
+
+import io.testaxis.backend.apiRoute
+import io.testaxis.backend.models.Build
+import io.testaxis.backend.repositories.BuildRepository
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.http.MediaType
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.get
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class BuildsControllerTest(@Autowired val mockMvc: MockMvc, @Autowired val buildRepository: BuildRepository) {
+    @Test
+    fun `A user can retrieve all builds for a given project`() {
+        val builds = buildRepository.saveAll(
+            listOf(
+                Build(branch = "new-feature", commit = "a212a3", slug = "org/project"),
+                Build(branch = "fix-bug", commit = "b72a73", slug = "org/other-project"),
+            )
+        ).toList()
+
+        mockMvc.get(apiRoute("/builds")) {
+            accept = MediaType.APPLICATION_JSON
+        }.andExpect {
+            status { isOk }
+
+            jsonPath("$[0].id") { value(builds[0].id!!) }
+            jsonPath("$[0].branch") { value("new-feature") }
+            jsonPath("$[0].commit") { value("a212a3") }
+            jsonPath("$[0].slug") { value("org/project") }
+
+            jsonPath("$[1].id") { value(builds[1].id!!) }
+            jsonPath("$[1].branch") { value("fix-bug") }
+            jsonPath("$[1].commit") { value("b72a73") }
+            jsonPath("$[1].slug") { value("org/other-project") }
+        }
+    }
+}

--- a/src/test/kotlin/io/testaxis/backend/http/controllers/api/ProjectControllerTest.kt
+++ b/src/test/kotlin/io/testaxis/backend/http/controllers/api/ProjectControllerTest.kt
@@ -11,16 +11,18 @@ import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.http.MediaType
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.get
+import javax.transaction.Transactional
 
 @SpringBootTest
+@Transactional
 @AutoConfigureMockMvc
 class ProjectControllerTest(@Autowired val mockMvc: MockMvc, @Autowired val projectRepository: ProjectRepository) {
     @Test
     fun `A user can retrieve all projects`() {
         val projects = projectRepository.saveAll(
             listOf(
-                Project(name = "example-project-a"),
-                Project(name = "example-project-b")
+                Project(name = "example-project-a", slug = "org/example-project-a"),
+                Project(name = "example-project-b", slug = "org/example-project-b")
             )
         )
 

--- a/src/test/kotlin/io/testaxis/backend/http/controllers/api/ProjectControllerTest.kt
+++ b/src/test/kotlin/io/testaxis/backend/http/controllers/api/ProjectControllerTest.kt
@@ -1,5 +1,6 @@
-package io.testaxis.backend.http.controllers
+package io.testaxis.backend.http.controllers.api
 
+import io.testaxis.backend.apiRoute
 import io.testaxis.backend.jsonContent
 import io.testaxis.backend.models.Project
 import io.testaxis.backend.repositories.ProjectRepository
@@ -23,7 +24,7 @@ class ProjectControllerTest(@Autowired val mockMvc: MockMvc, @Autowired val proj
             )
         )
 
-        mockMvc.get("/projects") {
+        mockMvc.get(apiRoute("/projects")) {
             accept = MediaType.APPLICATION_JSON
         }.andExpect {
             status { isOk }

--- a/src/test/kotlin/io/testaxis/backend/http/controllers/api/TestCaseExecutionsControllerTest.kt
+++ b/src/test/kotlin/io/testaxis/backend/http/controllers/api/TestCaseExecutionsControllerTest.kt
@@ -1,0 +1,119 @@
+package io.testaxis.backend.http.controllers.api
+
+import io.testaxis.backend.apiRoute
+import io.testaxis.backend.models.Build
+import io.testaxis.backend.models.Project
+import io.testaxis.backend.models.TestCaseExecution
+import io.testaxis.backend.repositories.BuildRepository
+import io.testaxis.backend.repositories.ProjectRepository
+import io.testaxis.backend.repositories.TestCaseExecutionRepository
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.http.MediaType
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.get
+import javax.persistence.EntityManager
+import javax.transaction.Transactional
+
+@SpringBootTest
+@Transactional
+@AutoConfigureMockMvc
+class TestCaseExecutionsControllerTest(
+    @Autowired val mockMvc: MockMvc,
+    @Autowired val testCaseExecutionRepository: TestCaseExecutionRepository,
+    @Autowired val buildRepository: BuildRepository,
+    @Autowired val projectRepository: ProjectRepository,
+    @Autowired val entityManager: EntityManager
+) {
+    lateinit var project: Project
+    lateinit var build: Build
+    lateinit var testCaseExecutions: List<TestCaseExecution>
+
+    @BeforeEach
+    fun setUp() {
+        project = projectRepository.save(Project(name = "project", slug = "org/project"))
+        build = buildRepository.save(Build(project = project, branch = "new-feature", commit = "a212a3", slug = "org/project"))
+        testCaseExecutions = testCaseExecutionRepository.saveAll(
+            listOf(
+                TestCaseExecution(
+                    build = build,
+                    testSuiteName = "io.testaxis.backend.http.controllers.ReportsControllerTest",
+                    name = "A user can upload a single report with build information that is persisted()",
+                    className = "io.testaxis.backend.http.controllers.ReportsControllerTest",
+                    time = 0.043,
+                    passed = true,
+                    failureMessage = null,
+                    failureType = null,
+                    failureContent = null,
+                ),
+                TestCaseExecution(
+                    build = build,
+                    testSuiteName = "io.testaxis.backend.http.controllers.ReportsControllerTest",
+                    name = "A user can upload multiple reports with build information that is persisted()",
+                    className = "io.testaxis.backend.http.controllers.ReportsControllerTest",
+                    time = 0.043,
+                    passed = false,
+                    failureMessage = "An error occurred",
+                    failureType = "org.opentest4j.AssertionFailedError",
+                    failureContent = "The stacktrace of the failure",
+                )
+            )
+        ).toList()
+        entityManager.refresh(build)
+    }
+
+    @Test
+    fun `A user can retrieve all test case executions for a given build`() {
+        mockMvc.get(apiRoute("/projects/${project.id}/builds/${build.id}/testcaseexecutions")) {
+            accept = MediaType.APPLICATION_JSON
+        }.andExpect {
+            status { isOk }
+
+            jsonPath("$[0].id") { value(testCaseExecutions[0].id!!) }
+            jsonPath("$[0].name") { value("A user can upload a single report with build information that is persisted()") }
+            jsonPath("$[0].class_name") { value("io.testaxis.backend.http.controllers.ReportsControllerTest") }
+            jsonPath("$[0].passed") { value(true) }
+            jsonPath("$[0].failure_message") { doesNotExist() }
+
+            jsonPath("$[1].id") { value(testCaseExecutions[1].id!!) }
+            jsonPath("$[1].name") { value("A user can upload multiple reports with build information that is persisted()") }
+            jsonPath("$[1].class_name") { value("io.testaxis.backend.http.controllers.ReportsControllerTest") }
+            jsonPath("$[1].passed") { value(false) }
+            jsonPath("$[1].failure_message") { doesNotExist() }
+        }
+    }
+
+    @Test
+    fun `A user can retrieve a successful single test case execution with more details`() {
+        mockMvc.get(apiRoute("/projects/${project.id}/builds/${build.id}/testcaseexecutions/${testCaseExecutions[0].id}")) {
+            accept = MediaType.APPLICATION_JSON
+        }.andExpect {
+            status { isOk }
+
+            jsonPath("$.id") { value(testCaseExecutions[0].id!!) }
+            jsonPath("$.name") { value("A user can upload a single report with build information that is persisted()") }
+            jsonPath("$.class_name") { value("io.testaxis.backend.http.controllers.ReportsControllerTest") }
+            jsonPath("$.passed") { value(true) }
+            jsonPath("$.failure_message") { isEmpty }
+        }
+    }
+
+    @Test
+    fun `A user can retrieve a failing single test case execution with more details`() {
+        mockMvc.get(apiRoute("/projects/${project.id}/builds/${build.id}/testcaseexecutions/${testCaseExecutions[1].id}")) {
+            accept = MediaType.APPLICATION_JSON
+        }.andExpect {
+            status { isOk }
+
+            jsonPath("$.id") { value(testCaseExecutions[1].id!!) }
+            jsonPath("$.name") { value("A user can upload multiple reports with build information that is persisted()") }
+            jsonPath("$.class_name") { value("io.testaxis.backend.http.controllers.ReportsControllerTest") }
+            jsonPath("$.passed") { value(false) }
+            jsonPath("$.failure_message") { value("An error occurred") }
+            jsonPath("$.failure_content") { value("The stacktrace of the failure") }
+        }
+    }
+}


### PR DESCRIPTION
This PR adds an endpoint for test case executions. It also makes other parts of the api/project more robust by introducing additional checks or guarantees (that a project exists).

Closes #22.