### PR TITLE
Add optional build status parameter for reports upload and update upload script

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,10 +48,6 @@ jobs:
     - name: Run ktlint with Gradle
       run: ./gradlew ktlintCheck
     - name: Upload test results to TestAxis
-      run: ./src/main/resources/static/testaxis-upload.bash -s build/test-results/test/
-      # Use `bash <(curl -s http://localhost:8080/testaxis-upload.bash)` to retrieve the upload script for other projects
-      if: always()
-    - name: Upload test results to TestAxis
       run: ./src/main/resources/static/testaxis-upload.bash -s build/test-results/test/ -p ${{ job.status }}
       # Use `bash <(curl -s http://localhost:8080/testaxis-upload.bash)` to retrieve the upload script for other projects
       if: always()

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,3 +51,7 @@ jobs:
       run: ./src/main/resources/static/testaxis-upload.bash -s build/test-results/test/
       # Use `bash <(curl -s http://localhost:8080/testaxis-upload.bash)` to retrieve the upload script for other projects
       if: always()
+    - name: Upload test results to TestAxis
+      run: ./src/main/resources/static/testaxis-upload.bash -s build/test-results/test/ -p ${{ job.status }}
+      # Use `bash <(curl -s http://localhost:8080/testaxis-upload.bash)` to retrieve the upload script for other projects
+      if: always()

--- a/src/main/kotlin/io/testaxis/backend/http/Validators.kt
+++ b/src/main/kotlin/io/testaxis/backend/http/Validators.kt
@@ -32,8 +32,8 @@ class FilesHaveTypeValidator : ConstraintValidator<FilesHaveType, Array<Multipar
         types = annotation.types.asList()
     }
 
-    override fun isValid(files: Array<MultipartFile>, context: ConstraintValidatorContext) =
-        files.all { types.contains(it.contentType) }
+    override fun isValid(files: Array<MultipartFile>?, context: ConstraintValidatorContext) =
+        files?.all { types.contains(it.contentType) } ?: true
 }
 
 /**
@@ -59,8 +59,8 @@ class FilesHaveMaxSizeValidator : ConstraintValidator<FilesHaveMaxSize, Array<Mu
         size = annotation.size
     }
 
-    override fun isValid(files: Array<MultipartFile>, context: ConstraintValidatorContext) =
-        files.all { it.size < size }
+    override fun isValid(files: Array<MultipartFile>?, context: ConstraintValidatorContext) =
+        files?.all { it.size < size } ?: true
 }
 
 /**

--- a/src/main/kotlin/io/testaxis/backend/http/controllers/ReportsController.kt
+++ b/src/main/kotlin/io/testaxis/backend/http/controllers/ReportsController.kt
@@ -4,6 +4,7 @@ import io.testaxis.backend.config.AppConfig
 import io.testaxis.backend.http.FilesHaveMaxSize
 import io.testaxis.backend.http.FilesHaveType
 import io.testaxis.backend.models.Build
+import io.testaxis.backend.models.BuildStatus
 import io.testaxis.backend.models.Project
 import io.testaxis.backend.repositories.ProjectRepository
 import io.testaxis.backend.services.ReportService
@@ -15,21 +16,20 @@ import org.springframework.web.bind.annotation.RestController
 import org.springframework.web.multipart.MultipartFile
 import javax.validation.Valid
 import javax.validation.constraints.NotBlank
-import javax.validation.constraints.NotEmpty
 
 @RestController
 @Validated
 class ReportsController(val reportService: ReportService, val projectRepository: ProjectRepository) {
     @PostMapping("reports")
     fun store(
-        @RequestParam("files") @NotEmpty
+        @RequestParam("files", required=false)
         @FilesHaveType(types = [MimeTypeUtils.APPLICATION_XML_VALUE, MimeTypeUtils.TEXT_XML_VALUE])
         @FilesHaveMaxSize(size = AppConfig.UPLOAD_LIMIT)
-        files: Array<MultipartFile>,
+        files: Array<MultipartFile>?,
         @Valid request: UploadReportRequest
     ) = reportService.parseAndPersistTestReports(
         request.toBuild(projectRepository.findBySlugOrCreate(request.slug)),
-        files.map { it.inputStream }
+        files?.map { it.inputStream } ?: emptyList()
     ).let { executions ->
         """
             -------------------------------------------
@@ -51,9 +51,11 @@ data class UploadReportRequest(
     val build: String?,
     @Suppress("ConstructorParameterNaming") val build_url: String?,
     val job: String?,
+    @Suppress("ConstructorParameterNaming") val build_status: String?,
 ) {
     fun toBuild(project: Project) = Build(
         project = project,
+        status = BuildStatus.values().find { it.name.toLowerCase() == build_status } ?: BuildStatus.UNKNOWN,
         branch = branch,
         commit = commit,
         slug = slug,

--- a/src/main/kotlin/io/testaxis/backend/http/controllers/ReportsController.kt
+++ b/src/main/kotlin/io/testaxis/backend/http/controllers/ReportsController.kt
@@ -22,7 +22,7 @@ import javax.validation.constraints.NotBlank
 class ReportsController(val reportService: ReportService, val projectRepository: ProjectRepository) {
     @PostMapping("reports")
     fun store(
-        @RequestParam("files", required=false)
+        @RequestParam("files", required = false)
         @FilesHaveType(types = [MimeTypeUtils.APPLICATION_XML_VALUE, MimeTypeUtils.TEXT_XML_VALUE])
         @FilesHaveMaxSize(size = AppConfig.UPLOAD_LIMIT)
         files: Array<MultipartFile>?,

--- a/src/main/kotlin/io/testaxis/backend/services/ReportService.kt
+++ b/src/main/kotlin/io/testaxis/backend/services/ReportService.kt
@@ -34,7 +34,9 @@ class ReportService(
                 }
             }.also { executions ->
                 build.testCaseExecutions.addAll(executions)
-                build.status = if (executions.all { it.passed }) BuildStatus.SUCCESS else BuildStatus.TESTS_FAILED
+                if (executions.any { !it.passed }) {
+                    build.status = BuildStatus.TESTS_FAILED
+                }
                 buildRepository.save(build)
 
                 applicationEventPublisher.publishEvent(BuildWasCreatedEvent(this, build))

--- a/src/main/resources/static/testaxis-upload.bash
+++ b/src/main/resources/static/testaxis-upload.bash
@@ -46,6 +46,7 @@ tag="$VCS_TAG"
 build_url="$CI_BUILD_URL"
 build="$CI_BUILD_ID"
 job="$CI_JOB_ID"
+build_status="unknown"
 
 proj_root="$git_root"
 
@@ -74,6 +75,13 @@ show_help() {
 
     -s DIR       Directory to search for test reports.
                  Already searches project root and artifact folders.
+
+    -p STATUS    The status of the build.
+                 Either the status supplied by a supported CI runner or one of the following values:
+                 success, build_failed, tests_failed, or unknown.
+                 The status will always be overridden to tests_failed if a test report with failing
+                 tests is uploaded.
+
     -t TOKEN     Set the private repository token
                  (option) set environment variable TESTAXIS_TOKEN=:uuid
 
@@ -104,8 +112,8 @@ show_help() {
 
     -- Communication --
     -u URL       Set the target url
-                 (option) Set environment variable TESTAXIS_URL=https://my-hosted-testaxis.com
-    -r SLUG      owner/repo slug of the porject
+                 (option) Set environment variable TESTAXIS_URL=https://my-hosted-testaxis.com/reports
+    -r SLUG      owner/repo slug of the project
                  (option) set environment variable TESTAXIS_SLUG=:owner/:repo
     -S PATH      File path to your cacert.pem file used to verify ssl
                  (option) Set environment variable: TESTAXIS_CA_BUNDLE="/path/to/ca.pem"
@@ -155,8 +163,14 @@ if [ $# != 0 ]; then
       e=""
       x=""
       ;;
+    "p")
+      build_status="$OPTARG"
+      ;;
     "P")
       pr_o="$OPTARG"
+      ;;
+    "r")
+      slug_o="$OPTARG"
       ;;
     "R")
       git_root="$OPTARG"
@@ -525,6 +539,13 @@ elif [ "$GITHUB_ACTIONS" != "" ]; then
   build="${GITHUB_RUN_ID}"
   build_url=$(urlencode "http://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}")
 
+  case "$build_status" in
+    "success") build_status="success" ;;
+    "failure") build_status="build_failed" ;;
+    "cancelled") build_status="build_failed" ;;
+    *) build_status="unknown" ;;
+  esac
+
 elif [ "$SYSTEM_TEAMFOUNDATIONSERVERURI" != "" ]; then
   say "$e==>$x Azure Pipelines detected."
   # https://docs.microsoft.com/en-us/azure/devops/pipelines/build/variables?view=vsts
@@ -662,7 +683,7 @@ fi
 query="branch=$branch       &commit=$commit       &build=$([ "$build_o" = "" ] && echo "$build" || echo "$build_o")\
        &build_url=$build_url       &tag=$([ "$tag_o" = "" ] && echo "$tag" || echo "$tag_o")\
        &slug=$urlencoded_slug       &service=$service       &pr=$([ "$pr_o" = "" ] && echo "${pr##\#}" || echo "${pr_o##\#}")\
-       &job=$job"
+       &job=$job       &build_status=$build_status"
 
 if [ -n "$project" ] && [ -n "$server_uri" ]; then
   query=$(echo "$query&project=$project&server_uri=$server_uri" | tr -d ' ')


### PR DESCRIPTION
Closes #28 and closes #29.

Accept custom build status and override if tests failed.
Also allow reports with 0 test files to add support for just reporting a build status