### PR TITLE
Collect coverage-per-test-reports and upload to TestAxis

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,9 +34,9 @@ jobs:
         key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
         restore-keys: ${{ runner.os }}-gradle
     - name: Build with Gradle
-      run: ./gradlew build -x check --info
+      run: ./gradlew build -x check --stacktrace
     - name: Run tests with Gradle
-      run: ./gradlew test --info
+      run: ./gradlew test coveragePerTest --stacktrace
       env:
         PG_HOST: localhost
         PG_USER: postgres
@@ -48,6 +48,6 @@ jobs:
     - name: Run ktlint with Gradle
       run: ./gradlew ktlintCheck
     - name: Upload test results to TestAxis
-      run: ./src/main/resources/static/testaxis-upload.bash -s build/test-results/test/ -p ${{ job.status }}
+      run: ./src/main/resources/static/testaxis-upload.bash -s build/test-results/test/ -c build/coveragepertest/xml -p ${{ job.status }}
       # Use `bash <(curl -s http://localhost:8080/testaxis-upload.bash)` to retrieve the upload script for other projects
       if: always()

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,6 +17,9 @@ plugins {
 
     id("io.gitlab.arturbosch.detekt") version "1.14.1"
     id("org.jlleitschuh.gradle.ktlint") version "9.4.1"
+
+    jacoco
+    id("io.testaxis.coveragepertest") version "1.0.0"
 }
 
 group = "io.testaxis"
@@ -53,7 +56,16 @@ allOpen {
     annotation("javax.persistence.MappedSuperclass")
 }
 
+jacoco {
+    toolVersion = "0.8.6"
+}
+
+tasks.coveragePerTestReport {
+    dependsOn(tasks.test)
+}
+
 tasks.withType<Test> {
+    systemProperty("junit.jupiter.extensions.autodetection.enabled", "true")
     useJUnitPlatform()
 }
 

--- a/src/main/resources/static/testaxis-upload.bash
+++ b/src/main/resources/static/testaxis-upload.bash
@@ -807,18 +807,18 @@ else
   say "${e}==>${x} Uploading coverage reports to TestAxis"
 
   # Construct file upload arguments
-  curl_files=""
+  curl_files=()
   if [ "$files" != "" ]; then
     # shellcheck disable=SC2089
     while IFS='' read -r file; do
-      curl_files="$curl_files -F files=@$file"
+      curl_files+=(-F "files=@$file")
     done <<<"$(echo -e "$files")"
   fi
 
   # shellcheck disable=SC2086,2090
   res=$(curl -X POST $curl_s $curlargs $cacert \
     --retry 5 --retry-delay 2 --connect-timeout 2 \
-    $curl_files \
+    "${curl_files[@]}" \
     --write-out "\nHTTP %{http_code}" \
     -o - \
     "$url?$query&attempt=$i" || echo 'HTTP 999')


### PR DESCRIPTION
Generate coverage-per-test reports and upload them to TestAxis during each build.