### PR TITLE
Increase allowed file/request size

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -19,6 +19,12 @@ spring:
               - user:email
               - read:user
 
+  servlet:
+    multipart:
+      enabled: true
+      max-file-size: 100MB
+      max-request-size: 100MB
+
 app:
   auth:
     tokenSecret: u0fNVcI5VfhURTascNxULCBBcw4ac8+8pdKQPEvkkmOqbyKj05PRy+cqMnqGDdHwanBd1/+jk4qBBuZ3F+cGUQ== # For development, production should override


### PR DESCRIPTION
Allow files larger than 10MB.

(needed to make the report upload of #49 pass)